### PR TITLE
Removes margin-top from hyperapp-one title

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -27,6 +27,7 @@ button {
 
 h1 {
   font-size: calc(20px + 6vmin);
+  margin-top: 0;
   margin-bottom: 1rem;
   text-align: center;
 }


### PR DESCRIPTION
Fixes https://github.com/selfup/hyperapp-one/issues/11 margin was offsetting the vertical centering.