### PR TITLE
add browser globals to eslint - upgrade to HA 0.18.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,4 +12,7 @@ module.exports = {
       'jsx': true,
     },
   },
+  'env': {
+    "browser": true,
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4154,9 +4154,9 @@
       "dev": true
     },
     "hyperapp": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/hyperapp/-/hyperapp-0.17.1.tgz",
-      "integrity": "sha512-QGIKTWLFw9JSS8AM+1stcaXDZEyJUdacTh3hhSgqRa30D2NVcy43nAMyyHLHROFhlLTnYZM2wPz0VA+Ia/PHeA=="
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/hyperapp/-/hyperapp-0.18.0.tgz",
+      "integrity": "sha512-b7KAOCzH1eK/st/C5bpgOksunhT/x9shBpsTV/ofB16vibz9ZXnIjZ6SV+9RrH4HzzkuvTYbVPj/EqANz3uvWA=="
     },
     "iconv-lite": {
       "version": "0.4.19",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Regis Boudinot (selfup)",
   "license": "MIT",
   "dependencies": {
-    "hyperapp": "^0.17.1"
+    "hyperapp": "^0.18.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -6,10 +6,7 @@ import { h } from 'hyperapp';
  * here we destructure what is needed
  * 'num' from 'state' and 'add'/'sub' from 'actions'
  */
-export default ({
-  state: { num },
-  actions: { add, sub },
-}) =>
+export default ({ num }, { add, sub }) =>
   <div class="counter">
     <h1>hyperapp-one</h1>
     <p><em>With JSX and Webpack</em></p>

--- a/src/index.js
+++ b/src/index.js
@@ -3,15 +3,12 @@ import actions from './actions';
 import state from './state';
 import view from './components/Counter';
 
-const model = {
+const {
+  add,
+  sub,
+} = app(
   state,
   actions,
-};
-
-const {
-  actions: dispatch,
-} = app(
-  model,
   view,
   document.body,
 );
@@ -23,5 +20,5 @@ const {
  * think of it as a hub to talk to other apps/frameworks/vanillaJS
  * here is an example on codepen: https://codepen.io/selfup/pen/jLMRjO
  */
-setTimeout(dispatch.add, 1000);
-setTimeout(dispatch.sub, 2000);
+setTimeout(add, 1000);
+setTimeout(sub, 2000);


### PR DESCRIPTION
### Upgrade to HA 0.18.1

Essentially 1.0.0.

### Upgrade eslintrc

To ensure that we can use `document.` or `window.`

🎉 